### PR TITLE
Upgrade to Piksi 2.4.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_options(-std=c++11)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
-  piksi_multi_rtk_ros
+  piksi_multi_cpp
 )
 
 catkin_package()

--- a/launch/waypoint.launch
+++ b/launch/waypoint.launch
@@ -5,6 +5,7 @@
   <arg name="speed" default="1.5" />
   <arg name="reverse" default="false" />
   <arg name="gps_fix" default="/piksi/navsatfix_best_fix" />
+  <arg name="gps_state" default="/piksi/receiver_state" />
   <arg name="gps_vel_ned" default="/piksi/vel_ned" />
 
   <node name="waypoint" pkg="ltu_actor_route_waypoint" type="waypoint">
@@ -14,6 +15,7 @@
     <param name="speed" value="$(arg speed)"/>
     <param name="reverse" value="$(arg reverse)"/>
     <param name="gps_fix" value="$(arg gps_fix)"/>
+    <param name="gps_state" value="$(arg gps_state)"/>
     <param name="gps_vel_ned" value="$(arg gps_vel_ned)"/>
   </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -9,11 +9,11 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>piksi_multi_rtk_ros</build_depend>
+  <build_depend>piksi_multi_cpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>piksi_multi_rtk_ros</build_export_depend>
+  <build_export_depend>piksi_multi_cpp</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>piksi_multi_rtk_ros</exec_depend>
+  <exec_depend>piksi_multi_cpp</exec_depend>
 </package>


### PR DESCRIPTION
JD | Update launch file and waypoint node to support upgrade to pikski 2.4.20, which uses the cpp implementation with different topics. NED topic no longer has num_of_sats, so that is disabled for now.